### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "babel": "6.5.2",
-    "babel-core": "6.7.4",
+    "babel-core": "6.10.4",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-plugin-transform-runtime": "6.6.0",
     "babel-preset-es2015": "6.6.0",


### PR DESCRIPTION
react-redux-boilerplateis currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:minimatch:20160620). 

Vulnerable module: `minimatch`
Introduced through: `babel-core`

This PR fixes the ReDOS  vulnerability by upgrading `babel-core` to version 6.10.4

You are already watching this repo with Snyk, so check out [the project](https://snyk.io/test/github/olegman/react-redux-boilerplate) to review other vulnerabilities that affect this repo, and generate a PR to fix more vulnerabilities. 

Stay secure, 
The Snyk team
